### PR TITLE
fixed quadratic updates

### DIFF
--- a/lib/ARP/SolrClient2/SolrCore.php
+++ b/lib/ARP/SolrClient2/SolrCore.php
@@ -366,11 +366,11 @@ class SolrCore extends CurlBrowser
         if (strlen($this->cache) > 1) {
             try {
                 $response = $this->jsonUpdate('{' . substr($this->cache, 0, -1) . '}');
-            } catch(\Exception $e) {
                 $this->cache = '';
+            } catch(\Exception $e) {
                 throw new \Exception($e->getMessage());
             }
-            
+
             return $response;
         }
         return null;


### PR DESCRIPTION
The document cache was not cleared after sending the first batch of documents, so the first documents would be sent over and over again, causing a quadratic number of documents being sent.